### PR TITLE
Fix an issue where this plugin would fail due to an IO issue related to archiving

### DIFF
--- a/opennms-warmerge-plugin/pom.xml
+++ b/opennms-warmerge-plugin/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.opennms.maven.plugins</groupId>
   <artifactId>opennms-warmerge-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.4-SNAPSHOT</version>
+  <version>0.5-SNAPSHOT</version>
   <name>opennms-warmerge-plugin Maven Mojo</name>
   <url>http://maven.apache.org</url>
   <build>
@@ -44,17 +44,17 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>1.0-alpha-12</version>
+      <version>4.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>2.0.5</version>
+      <version>3.2.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
I was running into the following issue trying to assemble OpenNMS:

[ERROR] Failed to execute goal org.opennms.maven.plugins:opennms-warmerge-plugin:0.4:warmerge (default) on project org.opennms.assemblies.webapp-full: Execution default of goal org.opennms.maven.plugins:opennms-warmerge-plugin:0.4:warmerge failed: invalid entry size -> [Help 1]

turns out updating the dependencies used by this plugin resolved the above error.