### PR TITLE
Plugin to generate the Maven module structure graph to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+.idea
+*.iml
+.factorypath

--- a/structure-maven-plugin/README.md
+++ b/structure-maven-plugin/README.md
@@ -1,0 +1,72 @@
+# Structure Maven Plugin
+
+## Overview
+
+This plugin is used to generate a graph of the Maven project structure in JSON format so that it can be analyzed by other applications.
+
+This plugins differs from others in that it does not follow transitive dependencies for artifacts that are not part of the project.
+
+## Usage
+
+```
+mvn org.opennms.maven.plugins:structure-maven-plugin:1.0-SNAPSHOT:structure
+``` 
+
+## Example output
+
+```
+[
+  {
+    "pom": "/home/jesse/git/opennms/pom.xml",
+    "dependencies": [],
+    "artifactId": "opennms",
+    "groupId": "org.opennms",
+    "version": "25.0.0-SNAPSHOT"
+  },
+  {
+    "pom": "/home/jesse/git/opennms/checkstyle/pom.xml",
+    "dependencies": [],
+    "artifactId": "org.opennms.checkstyle",
+    "groupId": "org.opennms",
+    "version": "25.0.0-SNAPSHOT"
+  },
+  {
+    "pom": "/home/jesse/git/opennms/dependencies/activemq/pom.xml",
+    "parent": {
+      "artifactId": "dependencies",
+      "groupId": "org.opennms",
+      "version": "25.0.0-SNAPSHOT"
+    },
+    "dependencies": [
+      {
+        "artifactId": "activemq-karaf",
+        "groupId": "org.apache.activemq",
+        "version": "5.14.5"
+      },
+      {
+        "artifactId": "activemq-jaas",
+        "groupId": "org.apache.activemq",
+        "version": "5.14.5"
+      },
+      {
+        "artifactId": "spring-dependencies",
+        "groupId": "org.opennms.dependencies",
+        "version": "25.0.0-SNAPSHOT"
+      },
+      {
+        "artifactId": "jcl-over-slf4j",
+        "groupId": "org.slf4j",
+        "version": "1.7.26"
+      },
+      {
+        "artifactId": "log4j-over-slf4j",
+        "groupId": "org.slf4j",
+        "version": "1.7.26"
+      }
+    ],
+    "artifactId": "activemq-dependencies",
+    "groupId": "org.opennms.dependencies",
+    "version": "25.0.0-SNAPSHOT"
+  },
+...
+```

--- a/structure-maven-plugin/pom.xml
+++ b/structure-maven-plugin/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.opennms.maven.plugins</groupId>
+  <artifactId>structure-maven-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>Structure Maven Plugin</name>
+
+  <url>https://github.com/OpenNMS/maven-plugins</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <gson.version>2.8.5</gson.version>
+    <maven.version>3.3.9</maven.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>test</scope>
+    </dependency> 
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.6.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <!-- <goalPrefix>maven-archetype-plugin</goalPrefix> -->
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.2.1</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/MavenIdentifier.java
+++ b/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/MavenIdentifier.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.maven.plugins;
+
+import java.util.Objects;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+
+public class MavenIdentifier {
+
+    private final String artifactId;
+    private final String groupId;
+    private final String version;
+
+    public MavenIdentifier(MavenProject project) {
+        this(project.getArtifactId(), project.getGroupId(), project.getVersion());
+    }
+
+    public MavenIdentifier(Dependency dependency) {
+        this(dependency.getArtifactId(), dependency.getGroupId(), dependency.getVersion());
+    }
+
+    public MavenIdentifier(String artifactId, String groupId, String version) {
+        this.artifactId = Objects.requireNonNull(artifactId);
+        this.groupId = Objects.requireNonNull(groupId);
+        this.version = Objects.requireNonNull(version);
+    }
+
+
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/StructureModule.java
+++ b/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/StructureModule.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.maven.plugins;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.project.MavenProject;
+
+public class StructureModule extends MavenIdentifier {
+
+    private final String pom;
+    private final MavenIdentifier parent;
+    private final List<MavenIdentifier> dependencies;
+
+    public StructureModule(MavenProject project) {
+        super(project);
+        this.pom = project.getFile().getAbsolutePath();
+        this.parent = project.getParent() != null ? new MavenIdentifier(project.getParent()) : null;
+
+        dependencies = project.getDependencies().stream()
+                .map(MavenIdentifier::new)
+                .collect(Collectors.toList());
+    }
+
+    public String getPom() {
+        return pom;
+    }
+
+    public MavenIdentifier getParent() {
+        return parent;
+    }
+
+    public List<MavenIdentifier> getDependencies() {
+        return dependencies;
+    }
+}

--- a/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/StructureMojo.java
+++ b/structure-maven-plugin/src/main/java/org/opennms/maven/plugins/StructureMojo.java
@@ -1,0 +1,74 @@
+package org.opennms.maven.plugins;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import com.google.gson.Gson;
+
+@Mojo(name = "structure", defaultPhase = LifecyclePhase.PROCESS_SOURCES )
+public class StructureMojo extends AbstractMojo {
+    /**
+     * Location of the file.
+     */
+    @Parameter( defaultValue = "${project.build.directory}", property = "outputDir", required = true )
+    private File outputDirectory;
+
+    /**
+     * Name of the file.
+     */
+    @Parameter(defaultValue = "structure-graph.json")
+    private String fileName;
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        // Only execute in the root
+        if (!project.isExecutionRoot()) {
+            return;
+        }
+
+        // Map
+        final List<StructureModule> modules = toModules(project);
+        getLog().info(String.format("Built structure %d modules.", modules.size()));
+
+        // Convert to JSON
+        final Gson gson = new Gson();
+        final String json = gson.toJson(modules);
+
+        // Write to file
+        final Path path = Paths.get(outputDirectory.getAbsolutePath(), fileName);
+        try {
+            getLog().info(String.format("Writing graph to: %s", path));
+            Files.write(path, json.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error occurred while writing graph to: " + path, e);
+        }
+    }
+
+    private static List<StructureModule> toModules(MavenProject project) {
+        final List<StructureModule> modules = new LinkedList<>();
+        modules.add(new StructureModule((project)));
+        for (MavenProject child : project.getCollectedProjects()) {
+            modules.add(new StructureModule(child));
+        }
+        return modules;
+    }
+
+}

--- a/structure-maven-plugin/src/test/java/org/opennms/maven/plugins/StructureModuleTest.java
+++ b/structure-maven-plugin/src/test/java/org/opennms/maven/plugins/StructureModuleTest.java
@@ -1,0 +1,37 @@
+package org.opennms.maven.plugins;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StructureModuleTest {
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    @Test
+    @Ignore
+    public void canRenderGraph() throws Exception {
+        File pom = new File( "target/test-classes/project-to-test/" );
+        assertNotNull( pom );
+        assertTrue( pom.exists() );
+
+        StructureMojo myMojo = (StructureMojo) rule.lookupConfiguredMojo( pom, "structure" );
+        assertNotNull( myMojo );
+        myMojo.execute();
+
+        File outputDirectory = ( File ) rule.getVariableValueFromObject( myMojo, "outputDirectory" );
+        assertNotNull( outputDirectory );
+        assertTrue( outputDirectory.exists() );
+
+        File graph = new File( outputDirectory, "structure-graph.json" );
+        assertTrue( graph.exists() );
+    }
+
+}
+

--- a/structure-maven-plugin/src/test/java/org/opennms/maven/plugins/StructureModuleTest.java
+++ b/structure-maven-plugin/src/test/java/org/opennms/maven/plugins/StructureModuleTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 
 import org.apache.maven.plugin.testing.MojoRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,7 +14,6 @@ public class StructureModuleTest {
     public MojoRule rule = new MojoRule();
 
     @Test
-    @Ignore
     public void canRenderGraph() throws Exception {
         File pom = new File( "target/test-classes/project-to-test/" );
         assertNotNull( pom );
@@ -23,6 +21,9 @@ public class StructureModuleTest {
 
         StructureMojo myMojo = (StructureMojo) rule.lookupConfiguredMojo( pom, "structure" );
         assertNotNull( myMojo );
+
+        rule.setVariableValueToObject( myMojo, "rootOnly", false);
+
         myMojo.execute();
 
         File outputDirectory = ( File ) rule.getVariableValueFromObject( myMojo, "outputDirectory" );

--- a/structure-maven-plugin/src/test/resources/project-to-test/pom.xml
+++ b/structure-maven-plugin/src/test/resources/project-to-test/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.opennms.maven.plugins</groupId>
+  <artifactId>structure-maven-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test MyMojo</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>structure-maven-plugin</artifactId>
+        <configuration>
+          <!-- Specify the StructureMojo parameter -->
+          <outputDirectory>target/test-harness/project-to-test</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12233 

As part of the effort in NMS-12233, we create a new Maven plugin that will export the Maven project structure in .json format so that it can be analyzed by other tools.
